### PR TITLE
Feat/copyright

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heybit-ui-styled-components",
   "customElements": "custom-elements.json",
-  "version": "0.34.6",
+  "version": "0.34.7",
   "files": [
     "dist/src/**"
   ],

--- a/src/components/organism/footer/index.ts
+++ b/src/components/organism/footer/index.ts
@@ -92,7 +92,7 @@ export class HbFooter extends Base {
 
   company = '업라이즈(주)';
 
-  copy = '© 2021 Uprise, Inc. all rights reserved.';
+  copy = `© ${new Date().getFullYear()} Uprise, Inc. all rights reserved.`;
 
   tel = '대표전화 1577-9069';
 


### PR DESCRIPTION
## 개요
푸터의 카피라이트 년도가 항상 최신으로 나오도록 업데이트 했습니다.

## 기타
년도가 최신으로 안나오다보니 관리가 되지 않는다는 느낌이 든다고 effy께서 먼저 제보를 해주었습니다.
이후 jake도 동의하여 반영했습니다.

![스크린샷 2022-11-17 오후 1 21 08](https://user-images.githubusercontent.com/107031216/202354917-6e6a8652-aa2c-4dd3-921b-e247037c99b2.png)
