### PR TITLE
feat: select 와 combobox 분리

### DIFF
--- a/src/components/molecule/combo/index.stories.ts
+++ b/src/components/molecule/combo/index.stories.ts
@@ -1,0 +1,84 @@
+import { Meta, Story } from '@storybook/web-components';
+import { html } from 'lit';
+import './index';
+import type { HbCombo } from './index';
+
+// More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
+export default {
+  title: 'components/molecule/hb-combo',
+  component: 'hb-combo'
+} as Meta;
+
+// More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
+const OpionSlotTmpl: Story<HbCombo> = ({ value, search, options, fixed, emptyText, placeholder }) =>
+  html`
+    <style>
+      .wrap {
+        position: relative;
+        display: inline-block;
+        overflow: scroll;
+        width: 500px;
+        /* height: 900px; */
+        padding: 30px;
+        background: blue;
+      }
+    </style>
+    <div class="wrap">
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <div style="height: 299px;"></div>
+      <hb-combo
+        value=${value}
+        ?fixed=${fixed}
+        ?search=${search}
+        .emptyText=${emptyText}
+        .options=${options}
+        .placeholder=${placeholder}
+        @event=${($event: Event) => console.log($event)}
+      ></hb-combo>
+      <div style="height: 99999px;"></div>
+    </div>
+  `;
+
+export const primary: Story<HbCombo> = OpionSlotTmpl.bind({});
+primary.args = {
+  search: false,
+  fixed: false,
+  value: '1',
+  // options: undefined,
+  placeholder: '블라블라',
+  emptyText: '내용이없습니다.',
+  options: [
+    { label: '1번', value: '1' },
+    { label: '2번', value: '2' },
+    { label: '3번', value: '3' },
+    { label: '4번', value: '4' },
+    { label: '5번', value: '5' },
+    { label: '6번', value: '6' },
+    { label: '7번', value: '7' },
+    { label: '8번', value: '8' },
+    { label: '9번', value: '9' },
+    { label: '10번', value: '10' },
+    { label: '11번', value: '11' },
+    { label: '12번', value: '12' },
+    { label: '13번', value: '13' },
+    { label: '14번', value: '14' },
+    { label: '15번', value: '15' },
+    { label: '16번', value: '16' },
+    { label: '17번', value: '17' },
+    { label: '18번', value: '18' },
+    { label: '19번', value: '19' },
+    { label: '20번', value: '20' },
+    { label: '21번', value: '21' },
+    { label: '22번', value: '22' },
+    { label: '23번', value: '23' },
+    { label: '24번', value: '24' }
+  ]
+};

--- a/src/components/molecule/combo/index.ts
+++ b/src/components/molecule/combo/index.ts
@@ -23,8 +23,8 @@ import { customElement } from 'lit/decorators.js';
  * @csspart list
  */
 
-@customElement('hb-select')
-export class HbSelect extends Base {
+@customElement('hb-combo')
+export class HbCombo extends Base {
   static get styles() {
     return [require('./style.scss').default];
   }
@@ -54,6 +54,8 @@ export class HbSelect extends Base {
   value = '';
 
   options: HbListOption[] = [];
+
+  placeholder = '검색어를 입력해주세요.';
 
   emptyText = '검색결과가 없습니다.';
 
@@ -86,6 +88,15 @@ export class HbSelect extends Base {
     return this.options?.filter((x) => x.label.includes(this.inputValue)) || [];
   }
 
+  get values() {
+    return this.options?.map((x) => x.value) || [];
+  }
+
+  get label() {
+    if (this.hasFocus || !this.options) return this.inputValue;
+    return this.options?.find((x) => x.value === this.value)?.label || '';
+  }
+
   get scrollEventListener() {
     if (this.parentQuery) return this.parentEl;
     return window;
@@ -93,40 +104,106 @@ export class HbSelect extends Base {
 
   render() {
     return html`
-      <select
-        class="hb-select__el"
-        @change=${this.onSelect}
-        ?disabled=${!this.list || !this.list.length}
+      <hb-input
+        class="hb-combo__label"
+        id="label"
+        part="label"
+        class="hb-combo__input"
+        ?readonly=${!this.search}
+        value=${this.label}
+        placeholder=${this.placeholder}
+        @event=${this.onInput}
       >
-        ${this.list && this.list.length
-          ? this.list.map((x) => html` <option value=${x.value}>${x.label}</option> `)
-          : html`<option>${this.emptyText}</option>`}
-      </select>
-      <span class="hb-select__icon-wrap">
+        <slot name="icon" class="hb-combo__label--icon"></slot>
         <hb-icon
-          class="hb-select__icon-wrap__el"
+          slot="slot--right"
           icon=${HbIconName['system/outline/arrow-dropdown']}
           size=${Size.small}
         ></hb-icon>
-      </span>
+      </hb-input>
+      <hb-transition id="select-transition" ?show=${this.open} type=${HbTransitionType.fade}>
+        <hb-list
+          tabindex="0"
+          emptyText=${this.emptyText}
+          id="list"
+          class="hb-combo__list${this.open ? ' hb-combo__list--open' : ''}"
+          style="width: ${this.width}px;transform: translate(${this.left}px,${this.top}px);"
+          @event=${this.onSelect}
+          .options=${this.list}
+          .value=${this.value}
+        ></hb-list>
+      </hb-transition>
     `;
+  }
+
+  async connectedCallback() {
+    await super.connectedCallback();
+    this.onfocus = () => this.adapterShow();
+    this.onblur = () => this.onHide();
+    this.inputEl = await getElement<HTMLInputElement>(this.shadowRoot, 'label');
+    if (this.parentQuery) this.parentEl = document.querySelector(this.parentQuery);
+  }
+
+  disconnectedCallback() {
+    this.onfocus = () => null;
+    this.onblur = () => null;
+  }
+
+  onScroll() {
+    const { bottom } = this.getBoundingClientRect();
+    if (bottom > 100) this.maxHeight = window.innerHeight - bottom - 50;
+    this.top = -(this.parentEl ? this.parentEl?.scrollTop : window.scrollY);
+    this.left = -(this.parentEl ? this.parentEl?.scrollLeft : window.scrollX);
+  }
+
+  onScrollBound = this.onScroll.bind(this);
+
+  onInput(ev: InputEvent) {
+    const { target } = ev;
+    if (!(target instanceof HbInput)) return;
+    this.inputValue = target.value;
   }
 
   onSelect(ev: Event) {
     ev.stopImmediatePropagation();
     const { target } = ev;
-    if (!(target instanceof HTMLSelectElement)) return;
+    if (!(target instanceof HbList)) return;
     const { value } = target;
     if (this.attributeSync) this.setAttribute('value', value!);
     this.value = value!;
     this.inputValue = '';
     // this.dispatchEvent(new CustomEvent('event', evt));
     this.onEvent(new CustomEvent('event'));
+    this.resolve();
+  }
+
+  onShow() {
+    const { width } = this.getBoundingClientRect();
+    this.open = true;
+    this.width = width;
+    if (this.search) this.hasFocus = true;
+    if (this.fixed) {
+      this.onScroll();
+      this.scrollEventListener.addEventListener('scroll', this.onScrollBound);
+    }
+  }
+
+  async adapterShow() {
+    this.onShow();
+    await new Promise((resolve) => (this.resolve = resolve));
+    this.onHide();
+  }
+
+  onHide() {
+    this.blur();
+    this.open = false;
+    if (this.search) this.hasFocus = false;
+    if (this.fixed) this.scrollEventListener.removeEventListener('scroll', this.onScrollBound);
   }
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'hb-select': HbSelect;
+    'hb-combo': HbCombo;
   }
 }

--- a/src/components/molecule/combo/style.scss
+++ b/src/components/molecule/combo/style.scss
@@ -2,35 +2,57 @@
 
 .hb-select {
   @include host-styled {
-    display: flex;
-    border-radius: calc(var(--husc__border__radius) * 2);
-    background: var(--husc__background__color);
-  }
-  &__el {
-    display: flex;
-    width: 100%;
-    min-height: var(--husc__input__minHeight);
-    max-height: var(--husc__input__maxHeight);
-    align-items: center;
-    color: var(--husc--black__800);
-    padding: var(--husc__input__padding__top) calc(var(--husc__input__padding__right) * 3)
-      var(--husc__input__padding__bottom) var(--husc__input__padding__left);
-    cursor: text;
-    font-size: var(--husc__input__font__size);
+    // z-index: zIndex("레이어");
+    // position: relative;
+    display: block;
     font-family: var(--husc__font__family);
-    border: var(--husc__input__border__width) solid var(--husc__input__border__color);
-    box-sizing: border-box;
-    border: 0;
-    background: none;
-    transition: border-color var(--husc__transition__duration--ms);
-    appearance: none;
+    font-size: var(--husc__select__font__size);
   }
-  &__icon-wrap {
-    width: 0;
+
+  &__select {
+    position: absolute;
+    height: 50px;
+    margin-top: -50px;
+    opacity: 0;
+  }
+
+  &__list {
+    position: absolute;
     pointer-events: none;
-    &__el {
-      height: 100%;
-      transform: translateX(-200%);
+    max-height: 70vh;
+    @include child-styled('[fixed]') {
+      position: fixed;
+      will-change: transform;
+    }
+    &--open {
+      pointer-events: auto;
+    }
+  }
+  // &__layer {
+  //   z-index: -1;
+  //   position: absolute;
+  //   top: 0;
+  //   right: 0;
+  //   bottom: 0;
+  //   left: 0;
+  // }
+  // &__input {
+  //   height: 100%;
+  //   padding: 0;
+  //   font-size: inherit;
+  //   flex: 1;
+  //   border: 0;
+  //   outline: none;
+  //   cursor: inherit;
+  // }
+  &__label {
+    // @extend %option;
+    cursor: pointer;
+
+    @include child-styled('.hb-select__list--open') {
+      &:not(:read-only) {
+        cursor: auto;
+      }
     }
   }
   // &__modal {

--- a/src/components/molecule/combo/type.ts
+++ b/src/components/molecule/combo/type.ts
@@ -1,0 +1,11 @@
+import type { HbListOption } from '@/index';
+
+export interface HbComboProps {
+  open?: boolean;
+  search?: boolean;
+  attributeSync?: boolean;
+  value?: string;
+  placeholder?: string;
+  emptyText?: string;
+  options?: HbListOption[];
+}

--- a/src/components/molecule/select/index.stories.ts
+++ b/src/components/molecule/select/index.stories.ts
@@ -10,14 +10,7 @@ export default {
 } as Meta;
 
 // More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
-const OpionSlotTmpl: Story<HbSelect> = ({
-  value,
-  search,
-  options,
-  fixed,
-  emptyText,
-  placeholder
-}) =>
+const OpionSlotTmpl: Story<HbSelect> = ({ value, options, emptyText }) =>
   html`
     <style>
       .wrap {
@@ -43,11 +36,8 @@ const OpionSlotTmpl: Story<HbSelect> = ({
       <div style="height: 299px;"></div>
       <hb-select
         value=${value}
-        ?fixed=${fixed}
-        ?search=${search}
         .emptyText=${emptyText}
         .options=${options}
-        .placeholder=${placeholder}
         @event=${($event: Event) => console.log($event)}
       ></hb-select>
       <div style="height: 99999px;"></div>
@@ -56,11 +46,8 @@ const OpionSlotTmpl: Story<HbSelect> = ({
 
 export const primary: Story<HbSelect> = OpionSlotTmpl.bind({});
 primary.args = {
-  search: false,
-  fixed: false,
-  value: '1',
+  value: '5',
   // options: undefined,
-  placeholder: '블라블라',
   emptyText: '내용이없습니다.',
   options: [
     { label: '1번', value: '1' },

--- a/src/components/molecule/select/index.ts
+++ b/src/components/molecule/select/index.ts
@@ -1,26 +1,14 @@
-import { HbTransitionType } from '@/components/atom/transition/type';
+import { HbIconName } from '@/components/atom/icon/type';
+import { HbListOption } from '@/components/atom/list/type';
 import { Size } from '@/components/atom/variable/type';
 import { Base } from '@/components/base';
-import { HbIconName } from '@/components/atom/icon/type';
-import { HbList } from '@/components/atom/list';
-import { HbListOption } from '@/components/atom/list/type';
-import { HbInput } from '@/components/molecule/input';
-import { getElement } from '@/utils';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 /**
  * @fires event 값이 변경될때 발생
- * @property attributeSync true 시 value값이 arrtibute 싱크됨
- * @property fixed true 시 overflow에서 넘어감
  * @property value 기본 값
  * @property options Options[] 옵션
- * @property search 서치 온오프
- * @slot icon - optional, icon부분을 커스텀할때 사용
- * @slot caret - optional, caret부분을 커스텀할때 사용
- * @slot option - required, select의 옵션 엘리먼트
- * @csspart label
- * @csspart list
  */
 
 @customElement('hb-select')
@@ -29,77 +17,34 @@ export class HbSelect extends Base {
     return [require('./style.scss').default];
   }
 
-  inputEl?: HTMLInputElement;
-
-  parentQuery?: string;
-
-  parentEl?: HTMLElement;
-
-  attributeSync = false;
-
-  fixed = false;
-
-  search = false;
-
-  open = false;
-
-  top: number;
-
-  left: number;
-
-  width: number;
-
-  maxHeight: number;
-
   value = '';
 
   options: HbListOption[] = [];
 
   emptyText = '검색결과가 없습니다.';
 
-  hasFocus = false;
-
-  inputValue = '';
-
-  resolve: (value?: unknown) => void = () => {};
-
   static get properties() {
     return {
-      open: { type: Boolean, Reflect: true },
-      search: { type: Boolean, Reflect: true },
-      attributeSync: { type: Boolean, Reflect: true },
-      fixed: { type: Boolean, Reflect: true },
-      top: { type: Number, Reflect: true },
-      left: { type: Number, Reflect: true },
-      width: { type: Number, Reflect: true },
-      maxHeight: { type: Number, Reflect: true },
       value: { type: String, Reflect: true },
       options: { type: Array, Reflect: true },
-      emptyText: { type: String, Reflect: true },
-      inputValue: { type: String, Reflect: true },
-      parentQuery: { type: String, Reflect: true },
-      hasFocus: { type: Boolean, Reflect: true }
+      emptyText: { type: String, Reflect: true }
     };
   }
 
   get list() {
-    return this.options?.filter((x) => x.label.includes(this.inputValue)) || [];
-  }
-
-  get scrollEventListener() {
-    if (this.parentQuery) return this.parentEl;
-    return window;
+    return this.options || [];
   }
 
   render() {
     return html`
-      <select
-        class="hb-select__el"
-        @change=${this.onSelect}
-        ?disabled=${!this.list || !this.list.length}
-      >
-        ${this.list && this.list.length
-          ? this.list.map((x) => html` <option value=${x.value}>${x.label}</option> `)
+      <select class="hb-select__el" @change=${this.onSelect} ?disabled=${!this.list.length}>
+        ${this.list.length
+          ? this.list.map(
+              (x) =>
+                html`
+                  <option ?selected=${this.value === x.value} value=${x.value}>${x.label}</option>
+                `
+            )
           : html`<option>${this.emptyText}</option>`}
       </select>
       <span class="hb-select__icon-wrap">
@@ -117,9 +62,7 @@ export class HbSelect extends Base {
     const { target } = ev;
     if (!(target instanceof HTMLSelectElement)) return;
     const { value } = target;
-    if (this.attributeSync) this.setAttribute('value', value!);
     this.value = value!;
-    this.inputValue = '';
     // this.dispatchEvent(new CustomEvent('event', evt));
     this.onEvent(new CustomEvent('event'));
   }

--- a/src/components/molecule/select/style.scss
+++ b/src/components/molecule/select/style.scss
@@ -4,6 +4,7 @@
   @include host-styled {
     display: flex;
     border-radius: calc(var(--husc__border__radius) * 2);
+    border: var(--husc__input__border__width) solid var(--husc__input__border__color);
     background: var(--husc__background__color);
   }
   &__el {
@@ -18,7 +19,6 @@
     cursor: text;
     font-size: var(--husc__input__font__size);
     font-family: var(--husc__font__family);
-    border: var(--husc__input__border__width) solid var(--husc__input__border__color);
     box-sizing: border-box;
     border: 0;
     background: none;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export * from '@/components/molecule/tooltip/type';
 export * from '@/components/molecule/button/type';
 export * from '@/components/molecule/input/type';
 export * from '@/components/molecule/select/type';
+export * from '@/components/molecule/combo/type';
 // export * from '@/components/organism/tab/type';
 export * from '@/components/molecule/carousel/type';
 export * from '@/components/molecule/modal/type';

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,6 +16,7 @@ export * from '@/components/molecule/tooltip';
 export * from '@/components/molecule/button';
 export * from '@/components/molecule/input';
 export * from '@/components/molecule/select';
+export * from '@/components/molecule/combo';
 export * from '@/components/molecule/tab';
 export * from '@/components/molecule/carousel';
 export * from '@/components/molecule/modal';


### PR DESCRIPTION
select는 네이티브 select에 디자인만 적용한걸로 분리, combo는 검색등 기본 기능을 커스터마이징한 셀렉트 박스로 보면 어떨까 싶은데, 지금 당장 뭔가 지정하긴 어렵고,, kyc에서 셀렉 기능만 필요합니다.