### PR TITLE
ci: 배포 방식을 merge 에서 tag 푸시로 변경

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -3,8 +3,8 @@ name: publish
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 
 jobs:
   publish:

--- a/.github/workflows/storybook_publish.yml
+++ b/.github/workflows/storybook_publish.yml
@@ -2,8 +2,8 @@ name: storybook deploy
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 
 jobs:
   publish:


### PR DESCRIPTION
## 개요

## 작업사항
머지로 하니까 도큐먼트 수정만으로도 배포가 되서, tag 로 통일합니다.
## 변경로직

### 변경전

### 변경후

## 사용방법

## 기타
