### PR TITLE
chore: currency 3자리이상 입력 안되는버그

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heybit-ui-styled-components",
   "customElements": "custom-elements.json",
-  "version": "0.37.17",
+  "version": "0.37.18",
   "files": [
     "dist/src/**"
   ],

--- a/src/components/molecule/input/index.ts
+++ b/src/components/molecule/input/index.ts
@@ -134,7 +134,7 @@ export class HbInput extends Base {
       }
 
       this._value = value;
-      if (inputEl && inputEl?.value !== value) inputEl.value = value;
+      if (inputEl && inputEl?.value !== this.originalValue) inputEl.value = value;
       else {
         this.onChange();
       }


### PR DESCRIPTION
## 개요

## 작업사항
커런시 입력창에서 입력받은 값이 3자리 이상부터 이벤트 발생하지 않음. 버그 해결
## 변경로직

### 변경전

### 변경후

## 사용방법

## 기타
