### PR TITLE
Feat/dialog

### DIFF
--- a/src/components/molecule/modal/dialog/index.stories.ts
+++ b/src/components/molecule/modal/dialog/index.stories.ts
@@ -58,7 +58,7 @@ export default {
     width: {
       description: 'normal type dialog에만 해당합니다.'
     },
-    scrollLock: {
+    preventBodyScroll: {
       description: `dialog가 열릴 때, modal-open 클래스 추가 여부를 결정합니다. 클래스가 있는 경우, body { overflow: hidden; }을 주어 스크롤 제어가 가능합니다.`,
       table: {
         defaultValue: { summary: 'true' }
@@ -109,7 +109,7 @@ export const Horizon: Story = {
   args: {
     layout: 'normal',
     width: '1000px',
-    scrollLock: true,
+    preventBodyScroll: true,
     open: false,
     persistent: false,
     loading: false,

--- a/src/components/molecule/modal/dialog/index.ts
+++ b/src/components/molecule/modal/dialog/index.ts
@@ -66,7 +66,7 @@ export class HbDialog extends Base {
 
   disabled: boolean;
 
-  scrollLock = true;
+  preventBodyScroll = true;
 
   get transitionType(): HbTransitionType {
     return this.layout === 'sheet' ? 'bottom-up' : 'zoom';
@@ -85,7 +85,7 @@ export class HbDialog extends Base {
       buttons: { type: Array, Reflect: true },
       anchor: { type: Object, Reflect: true },
       disabled: { type: Boolean, Reflect: true },
-      scrollLock: { type: Boolean, Reflect: true },
+      preventBodyScroll: { type: Boolean, Reflect: true },
       eventDisabled: { type: Boolean, Reflect: true },
       persistent: { type: Boolean, Reflect: true },
       hideCloseBtn: { type: Boolean, Reflect: true },
@@ -102,7 +102,7 @@ export class HbDialog extends Base {
   }
 
   render() {
-    document.body.classList.toggle('modal-open', this.scrollLock && this.open);
+    document.body.classList.toggle('modal-open', this.preventBodyScroll && this.open);
     return html`
       <hb-modal
         @close=${this.onClose}

--- a/src/components/molecule/modal/dialog/style.scss
+++ b/src/components/molecule/modal/dialog/style.scss
@@ -32,7 +32,7 @@
     }
     &.page-layout {
       width: 100vw;
-      height: 100vh;
+      height: 100dvh;
       max-height: none;
       margin: 0;
       padding: var(--husc__modal__margin);

--- a/src/components/molecule/modal/page-dialog/style.scss
+++ b/src/components/molecule/modal/page-dialog/style.scss
@@ -18,7 +18,7 @@
 
     flex-direction: column;
     width: 100vw;
-    height: 100vh;
+    height: 100dvh;
     padding: 60px var(--husc__modal__margin) var(--husc__modal__margin) var(--husc__modal__margin);
     box-sizing: border-box;
     background: var(--husc__modal__background);


### PR DESCRIPTION
## 개요
iOS Safari 15이상 버전에서 발생하여,
모바일 기기 하단의 url bar가 fixed 된 모달의 하단 영역을 가리는 문제가 있습니다.
버튼이 위치하는 경우 누를 수 없는 문제가 발생하므로 해결하고자 합니다.

## 참고
https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/
