### PR TITLE
Fix/deploy url error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heybit-ui-styled-components",
   "customElements": "custom-elements.json",
-  "version": "0.41.10",
+  "version": "0.41.11-dev.1",
   "files": [
     "dist/src/**"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heybit-ui-styled-components",
   "customElements": "custom-elements.json",
-  "version": "0.41.11-dev.1",
+  "version": "0.41.11-dev.2",
   "files": [
     "dist/src/**"
   ],

--- a/src/components/atom/alert/index.ts
+++ b/src/components/atom/alert/index.ts
@@ -21,21 +21,11 @@ export class HbAlert extends Base {
     return [require('./style.scss').default];
   }
 
-  _color: string = '';
-
-  get color() {
-    return this._color;
-  }
-
-  set color(value: string) {
-    this._color = value;
-    if (value) this.setAttribute('color', value);
-    else this.removeAttribute('color');
-  }
+  color = '';
 
   static get properties() {
     return {
-      color: { type: String, Reflect: true }
+      color: { type: String, reflect: true }
     };
   }
 

--- a/src/components/atom/chip/index.ts
+++ b/src/components/atom/chip/index.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 import { Base } from '@/components/base';
 /**
  * @property color 지정 테마
@@ -12,7 +12,12 @@ export class HbChip extends Base {
     return [require('./style.scss').default];
   }
 
-  @property({ reflect: true })
+  static get properties() {
+    return {
+      color: { reflect: true }
+    };
+  }
+
   color = '';
 
   render() {


### PR DESCRIPTION
## 개요
데코레이터 이전의 방식으로 돌리되 좀 더 나은 방식으로 변경했습니다.
(Reflect -> reflect, 그동안 대문자로 잘못 사용하고 있던게 핵심 원인이었습니다.)
alert 컴포넌트도 동일한 이슈가 있어서 같이 수정했습니다.

## 기타
데코레이터 방식으로 진행하니 사용은 되나 다음의 에러가 발생하여 다시 수정한 것입니다.
(로컬에서는 발생하지 않는대 배포만하면 발생하네요.)
Cannot read properties of undefined (reading 'constructor')
<img width="770" alt="스크린샷 2023-08-07 오후 12 53 48" src="https://github.com/uprise-fin/heybit-ui-styled-components/assets/7262465/af183a13-1f11-465e-b862-ca1839352da1">

